### PR TITLE
Add support for chunked encoding and larger bodies

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -132,7 +132,10 @@ int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
 
         if (hasBody)
         {
-                write(aBody, aContentLength);
+            for (int i = 0; i < aContentLength; i += 1024)
+            {
+                write(aBody + i, min(aContentLength - i, 1024));
+            }
         }
     }
 

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -32,8 +32,8 @@ void HttpClient::resetState()
 {
   iState = eIdle;
   iStatusCode = 0;
-  iContentLength = 0;
   iBodyLengthConsumed = 0;
+  iContentLength = kNoContentLengthHeader;
   iContentLengthPtr = kContentLengthPrefix;
   iHttpResponseTimeout = kHttpResponseTimeout;
 }

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -59,7 +59,7 @@ void HttpClient::beginRequest()
   iState = eRequestStarted;
 }
 
-int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod, 
+int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
                                 const char* aContentType, int aContentLength, const byte aBody[])
 {
     if (iState == eReadingBody)
@@ -96,7 +96,7 @@ int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
                 Serial.println("Connection failed");
 #endif
                 return HTTP_ERROR_CONNECTION_FAILED;
-            }    
+            }
         }
     }
     else
@@ -385,7 +385,7 @@ int HttpClient::responseStatusCode()
         const char* statusPrefix = "HTTP/*.* ";
         const char* statusPtr = statusPrefix;
         // Whilst we haven't timed out & haven't reached the end of the headers
-        while ((c != '\n') && 
+        while ((c != '\n') &&
                ( (millis() - timeoutStart) < iHttpResponseTimeout ))
         {
             if (available())
@@ -478,7 +478,7 @@ int HttpClient::skipResponseHeaders()
     // Just keep reading until we finish reading the headers or time out
     unsigned long timeoutStart = millis();
     // Whilst we haven't timed out & haven't reached the end of the headers
-    while ((!endOfHeadersReached()) && 
+    while ((!endOfHeadersReached()) &&
            ( (millis() - timeoutStart) < iHttpResponseTimeout ))
     {
         if (available())
@@ -508,7 +508,7 @@ int HttpClient::skipResponseHeaders()
 
 int HttpClient::contentLength()
 {
-    // skip the response headers, if they haven't been read already 
+    // skip the response headers, if they haven't been read already
     if (!endOfHeadersReached())
     {
         skipResponseHeaders();
@@ -684,7 +684,7 @@ bool HttpClient::headerAvailable()
             {
                 // end of the line, all done
                 break;
-            } 
+            }
             else
             {
                 // ignore any CR or LF characters

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -305,6 +305,10 @@ protected:
     */
     void flushClientRx();
 
+    /** Helper function to convert a hex nibble to an interger value
+    */
+    int hexToDec(char c);
+
     // Number of milliseconds that we wait each time there isn't any data
     // available to be read (during status code and header processing)
     static const int kHttpWaitForDataDelay = 1000;


### PR DESCRIPTION
This adds support for chunked transfer encodings and larger body writes. It also makes `HttpClient::responseBody()` more robust, similar to what #7 does.

Replaces / conflicts with #7 
Fixes #3
