### PR TITLE
Allow custom headers between startRequest & endRequest

### DIFF
--- a/examples/CustomHeaders/CustomHeaders.ino
+++ b/examples/CustomHeaders/CustomHeaders.ino
@@ -1,0 +1,89 @@
+/*
+
+  Custom request header example for the ArduinoHttpClient
+  library. This example sends a GET request with a custom header every 5 seconds.
+
+  note: WiFi SSID and password are stored in config.h file.
+  If it is not present, add a new tab, call it "config.h"
+  and add the following variables:
+  char ssid[] = "ssid";     //  your network SSID (name)
+  char pass[] = "password"; // your network password
+
+  based on SimpleGet example by Tom Igoe
+  header modifications by Todd Treece
+
+  this example is in the public domain
+ */
+#include <ArduinoHttpClient.h>
+#include <WiFi101.h>
+#include "config.h"
+
+char serverAddress[] = "192.168.0.3";  // server address
+int port = 8080;
+
+WiFiClient wifi;
+HttpClient client = HttpClient(wifi, serverAddress, port);
+int status = WL_IDLE_STATUS;
+String response;
+int statusCode = 0;
+
+void setup() {
+  Serial.begin(9600);
+  while ( status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to Network named: ");
+    Serial.println(ssid);                   // print the network name (SSID);
+
+    // Connect to WPA/WPA2 network:
+    status = WiFi.begin(ssid, pass);
+  }
+
+  // print the SSID of the network you're attached to:
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // print your WiFi shield's IP address:
+  IPAddress ip = WiFi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+}
+
+void loop() {
+
+  Serial.println("making GET request");
+  client.startRequest("/", HTTP_METHOD_GET);
+  client.sendHeader("X-CUSTOM-HEADER", "custom_value");
+  client.endRequest();
+
+  // read the status code and body of the response
+  statusCode = client.responseStatusCode();
+  response = client.responseBody();
+
+  Serial.print("GET Status code: ");
+  Serial.println(statusCode);
+  Serial.print("GET Response: ");
+  Serial.println(response);
+
+  Serial.println("Wait five seconds");
+  delay(5000);
+
+  Serial.println("making POST request");
+  String postData = "name=Alice&age=12";
+  client.startRequest("/", HTTP_METHOD_POST);
+  client.sendHeader(HTTP_HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
+  client.sendHeader(HTTP_HEADER_CONTENT_LENGTH, postData.length());
+  client.sendHeader("X-CUSTOM-HEADER", "custom_value");
+  client.endRequest();
+  client.write((const byte*)postData.c_str(), postData.length());
+
+  // read the status code and body of the response
+  statusCode = client.responseStatusCode();
+  response = client.responseBody();
+
+  Serial.print("POST Status code: ");
+  Serial.println(statusCode);
+  Serial.print("POST Response: ");
+  Serial.println(response);
+
+  Serial.println("Wait five seconds");
+  delay(5000);
+}

--- a/examples/CustomHeaders/config.h
+++ b/examples/CustomHeaders/config.h
@@ -1,0 +1,2 @@
+char ssid[] = "ssid";     //  your network SSID (name)
+char pass[] = "password"; // your network password

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -123,16 +123,11 @@ int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
 
         bool hasBody = (aBody && aContentLength > 0);
 
-        if (initialState == eIdle || hasBody)
+        if (hasBody)
         {
             // This was a simple version of the API, so terminate the headers now
             finishHeaders();
-        }
-        // else we'll call it in endRequest or in the first call to print, etc.
-
-        if (hasBody)
-        {
-                write(aBody, aContentLength);
+            write(aBody, aContentLength);
         }
     }
 
@@ -274,7 +269,11 @@ void HttpClient::endRequest()
 
 int HttpClient::get(const char* aURLPath)
 {
-    return startRequest(aURLPath, HTTP_METHOD_GET);
+    int ret = startRequest(aURLPath, HTTP_METHOD_GET);
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+    return ret;
 }
 
 int HttpClient::get(const String& aURLPath)
@@ -284,7 +283,13 @@ int HttpClient::get(const String& aURLPath)
 
 int HttpClient::post(const char* aURLPath)
 {
-    return startRequest(aURLPath, HTTP_METHOD_POST);
+    int ret = startRequest(aURLPath, HTTP_METHOD_POST);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::post(const String& aURLPath)
@@ -304,12 +309,24 @@ int HttpClient::post(const String& aURLPath, const String& aContentType, const S
 
 int HttpClient::post(const char* aURLPath, const char* aContentType, int aContentLength, const byte aBody[])
 {
-    return startRequest(aURLPath, HTTP_METHOD_POST, aContentType, aContentLength, aBody);
+    int ret = startRequest(aURLPath, HTTP_METHOD_POST, aContentType, aContentLength, aBody);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::put(const char* aURLPath)
 {
-    return startRequest(aURLPath, HTTP_METHOD_PUT);
+    int ret = startRequest(aURLPath, HTTP_METHOD_PUT);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::put(const String& aURLPath)
@@ -329,12 +346,24 @@ int HttpClient::put(const String& aURLPath, const String& aContentType, const St
 
 int HttpClient::put(const char* aURLPath, const char* aContentType, int aContentLength, const byte aBody[])
 {
-    return startRequest(aURLPath, HTTP_METHOD_PUT, aContentType, aContentLength, aBody);
+    int ret = startRequest(aURLPath, HTTP_METHOD_PUT, aContentType, aContentLength, aBody);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::del(const char* aURLPath)
 {
-    return startRequest(aURLPath, HTTP_METHOD_DELETE);
+    int ret = startRequest(aURLPath, HTTP_METHOD_DELETE);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::del(const String& aURLPath)
@@ -354,7 +383,13 @@ int HttpClient::del(const String& aURLPath, const String& aContentType, const St
 
 int HttpClient::del(const char* aURLPath, const char* aContentType, int aContentLength, const byte aBody[])
 {
-    return startRequest(aURLPath, HTTP_METHOD_DELETE, aContentType, aContentLength, aBody);
+    int ret = startRequest(aURLPath, HTTP_METHOD_DELETE, aContentType, aContentLength, aBody);
+
+    if (HTTP_SUCCESS == ret) {
+      endRequest();
+    }
+
+    return ret;
 }
 
 int HttpClient::responseStatusCode()


### PR DESCRIPTION
## Changes

This change allows users to build more complex requests with custom headers when using `startRequest` and `endRequest`. Calls to the `get`, `post`, `put`, and `del` helpers will end the request as they did before.
## Tests

**SimpleGet.ino**:

```
making GET request
Status code: 200
Response: OK
Wait five seconds
```

**SimplePost**:

```
making POST request
Status code: 200
Response: OK
Wait five seconds
```

**SimplePut**:

```
making PUT request
Status code: 200
Response: OK
Wait five seconds
```

**SimpleDelete**:

```
making DELETE request
Status code: 200
Response: OK
Wait five seconds
```
