### PR TITLE
Fix incorrect return value, resulting in compilation error, being there for 8 years!

### DIFF
--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -168,7 +168,7 @@ public:
     /** Send an additional header line.  This can only be called in between the
       calls to beginRequest and endRequest.
       @param aHeader Header line to send, in its entirety (but without the
-                     trailing CRLF.  E.g. "Authorization: Basic YQDDCAIGES" 
+                     trailing CRLF.  E.g. "Authorization: Basic YQDDCAIGES"
     */
     void sendHeader(const char* aHeader);
 
@@ -307,7 +307,7 @@ public:
     virtual int read();
     virtual int read(uint8_t *buf, size_t size);
     virtual int peek() { return iClient->peek(); };
-    virtual void flush() { return iClient->flush(); };
+    virtual void flush() { iClient->flush(); };
 
     // Inherited from Client
     virtual int connect(IPAddress ip, uint16_t port) { return iClient->connect(ip, port); };


### PR DESCRIPTION
Error in question:

```
ArduinoHttpClient/src/HttpClient.h: In member function 'virtual void HttpClient::flush()':
ArduinoHttpClient/src/HttpClient.h:310:50: error: return-statement with a value, in function returning 'void' [-fpermissive]
```

Now this one really pissed me off. It is not the error itself, but a fact that this was ignored from the first time it was uploaded to GitHub:

```
$ git blame -L 309,311 -- src/HttpClient.h

^6e63262 HttpClient.h (amcewen 2011-05-14 14:42:26 +0100 309)     virtual int peek() { return iClient->peek(); };
^6e63262 HttpClient.h (amcewen 2011-05-14 14:42:26 +0100 310)     virtual void flush() { return iClient->flush(); };
```

...**AND**  [ESP team was knowing about it]( https://github.com/esp8266/Arduino/commit/83a8076db87b77de6a7b500c18b85057e38ed117#diff-85122eee893fae8c5a39b442c776687cR75) and no one give a single bit of effort porting that change into mainstream. Despite hundreds of people using arduino ecosystem and this lib.

It looks even more retarded , that avr-gcc let it pass trough. 

Notes for future: please add CI here with grain of static analysis tool. It is not that hard.
