### PR TITLE
Add URL Encoder class

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,7 @@
 ArduinoHttpClient	KEYWORD1
 HttpClient	KEYWORD1
 WebSocketClient	KEYWORD1
+URLEncoder	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -46,6 +47,8 @@ messageType	KEYWORD2
 isFinal	KEYWORD2
 readString	KEYWORD2
 ping	KEYWORD2
+
+encode	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/ArduinoHttpClient.h
+++ b/src/ArduinoHttpClient.h
@@ -7,5 +7,6 @@
 
 #include "HttpClient.h"
 #include "WebSocketClient.h"
+#include "URLEncoder.h"
 
 #endif

--- a/src/URLEncoder.cpp
+++ b/src/URLEncoder.cpp
@@ -1,0 +1,53 @@
+// Library to simplify HTTP fetching on Arduino
+// (c) Copyright Arduino. 2019
+// Released under Apache License, version 2.0
+
+#include "URLEncoder.h"
+
+URLEncoderClass::URLEncoderClass()
+{
+}
+
+URLEncoderClass::~URLEncoderClass()
+{
+}
+
+String URLEncoderClass::encode(const char* str)
+{
+    return encode(str, strlen(str));
+}
+
+String URLEncoderClass::encode(const String& str)
+{
+    return encode(str.c_str(), str.length());
+}
+
+String URLEncoderClass::encode(const char* str, int length)
+{
+    String encoded;
+
+    encoded.reserve(length);
+
+    for (int i = 0; i < length; i++) {
+        char c = str[i];
+
+        const char HEX_DIGIT_MAPPER[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+        if (isAlphaNumeric(c) || (c == '-') || (c == '.') || (c == '_') || (c == '~')) {
+            encoded += c;
+        } else {
+            char s[4];
+
+            s[0] = '%';
+            s[1] = HEX_DIGIT_MAPPER[(c >> 4) & 0xf];
+            s[2] = HEX_DIGIT_MAPPER[(c & 0x0f)];
+            s[3] = 0;
+
+            encoded += s;
+        }
+    }
+
+    return encoded;
+}
+
+URLEncoderClass URLEncoder;

--- a/src/URLEncoder.h
+++ b/src/URLEncoder.h
@@ -13,11 +13,11 @@ public:
     URLEncoderClass();
     virtual ~URLEncoderClass();
 
-    String encode(const char* str);
-    String encode(const String& str);
+    static String encode(const char* str);
+    static String encode(const String& str);
 
 private:
-    String encode(const char* str, int length);
+    static String encode(const char* str, int length);
 };
 
 extern URLEncoderClass URLEncoder;

--- a/src/URLEncoder.h
+++ b/src/URLEncoder.h
@@ -1,0 +1,25 @@
+// Library to simplify HTTP fetching on Arduino
+// (c) Copyright Arduino. 2019
+// Released under Apache License, version 2.0
+
+#ifndef URL_ENCODER_H
+#define URL_ENCODER_H
+
+#include <Arduino.h>
+
+class URLEncoderClass
+{
+public:
+    URLEncoderClass();
+    virtual ~URLEncoderClass();
+
+    String encode(const char* str);
+    String encode(const String& str);
+
+private:
+    String encode(const char* str, int length);
+};
+
+extern URLEncoderClass URLEncoder;
+
+#endif


### PR DESCRIPTION
As discussed with @tigoe, is this what you had in mind or do you prefer a C style API without the class? (Something like `urlencode(input)`)