### PR TITLE
Add ESP32/ESP8266 support in HttpClient.h

### DIFF
--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -312,6 +312,19 @@ public:
     // Inherited from Client
     virtual int connect(IPAddress ip, uint16_t port) { return iClient->connect(ip, port); };
     virtual int connect(const char *host, uint16_t port) { return iClient->connect(host, port); };
+    
+    #ifdef ESP32 || ESP8266
+    virtual int connect(IPAddress ip, uint16_t port, int timeout)
+    {
+        throw "Method [virtual int connect(IPAddress ip, uint16_t port, int timeout)] is not implemented in TinyGsmClientSIM800.h";
+    }
+
+    virtual int connect(const char *host, uint16_t port, int timeout)
+    {
+        throw "Method [virtual int connect(const char *host, uint16_t port, int timeout)] is not implemented in TinyGsmClientSIM800.h";
+    }
+    #endif
+    
     virtual void stop();
     virtual uint8_t connected() { return iClient->connected(); };
     virtual operator bool() { return bool(iClient); };


### PR DESCRIPTION
In ESP32/ESP8266 in Client there are two additional abstract methods exists:
    virtual int connect(IPAddress ip, uint16_t port, int timeout) =0;
    virtual int connect(const char *host, uint16_t port, int timeout) =0;
They are not implemented in HttpClient.h, so compilations stops with error.