### PR TITLE
Using ServerAddress for Host header

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -181,14 +181,17 @@ int HttpClient::sendInitialHeaders(const char* aURLPath, const char* aHttpMethod
 
 void HttpClient::sendHostHeader() 
 {
-    if(iServerName || iUseServerAddressForHostHeader) {
+    if(iServerName || iUseServerAddressForHostHeader) 
+    {
         iClient->print(HTTP_HEADER_HOST);
         iClient->print(": ");
 
         if (iServerName)
         {
             iClient->print(iServerName);
-        } else if(iUseServerAddressForHostHeader) {
+        } 
+        else if(iUseServerAddressForHostHeader) 
+        {
             iClient->print(iServerAddress);
         }
 

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -12,7 +12,7 @@ const char* HttpClient::kTransferEncodingChunked = HTTP_HEADER_TRANSFER_ENCODING
 
 HttpClient::HttpClient(Client& aClient, const char* aServerName, uint16_t aServerPort)
  : iClient(&aClient), iServerName(aServerName), iServerAddress(), iServerPort(aServerPort),
-   iConnectionClose(true), iSendDefaultRequestHeaders(true)
+   iConnectionClose(true), iSendDefaultRequestHeaders(true), iUseServerAddressForHostHeader(false)
 {
   resetState();
 }
@@ -24,7 +24,7 @@ HttpClient::HttpClient(Client& aClient, const String& aServerName, uint16_t aSer
 
 HttpClient::HttpClient(Client& aClient, const IPAddress& aServerAddress, uint16_t aServerPort)
  : iClient(&aClient), iServerName(NULL), iServerAddress(aServerAddress), iServerPort(aServerPort),
-   iConnectionClose(true), iSendDefaultRequestHeaders(true)
+   iConnectionClose(true), iSendDefaultRequestHeaders(true), iUseServerAddressForHostHeader(false)
 {
   resetState();
 }
@@ -56,6 +56,11 @@ void HttpClient::connectionKeepAlive()
 void HttpClient::noDefaultRequestHeaders()
 {
   iSendDefaultRequestHeaders = false;
+}
+
+void HttpClient::useServerAddressForHostHeader()
+{ 
+  iUseServerAddressForHostHeader = true;
 }
 
 void HttpClient::beginRequest()
@@ -157,17 +162,7 @@ int HttpClient::sendInitialHeaders(const char* aURLPath, const char* aHttpMethod
     if (iSendDefaultRequestHeaders)
     {
         // The host header, if required
-        if (iServerName)
-        {
-            iClient->print("Host: ");
-            iClient->print(iServerName);
-            if (iServerPort != kHttpPort)
-            {
-              iClient->print(":");
-              iClient->print(iServerPort);
-            }
-            iClient->println();
-        }
+        sendHostHeader();
         // And user-agent string
         sendHeader(HTTP_HEADER_USER_AGENT, kUserAgent);
     }
@@ -183,6 +178,29 @@ int HttpClient::sendInitialHeaders(const char* aURLPath, const char* aHttpMethod
     iState = eRequestStarted;
     return HTTP_SUCCESS;
 }
+
+void HttpClient::sendHostHeader() 
+{
+    if(iServerName || iUseServerAddressForHostHeader) {
+        iClient->print(HTTP_HEADER_HOST);
+        iClient->print(": ");
+
+        if (iServerName)
+        {
+            iClient->print(iServerName);
+        } else if(iUseServerAddressForHostHeader) {
+            iClient->print(iServerAddress);
+        }
+
+        if (iServerPort != kHttpPort)
+        {
+          iClient->print(":");
+          iClient->print(iServerPort);
+        }
+        iClient->println();
+    }
+}
+
 
 void HttpClient::sendHeader(const char* aHeader)
 {

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -34,6 +34,7 @@ static const int HTTP_ERROR_INVALID_RESPONSE =-4;
 #define HTTP_HEADER_CONTENT_LENGTH "Content-Length"
 #define HTTP_HEADER_CONTENT_TYPE   "Content-Type"
 #define HTTP_HEADER_CONNECTION     "Connection"
+#define HTTP_HEADER_HOST           "Host"
 #define HTTP_HEADER_TRANSFER_ENCODING "Transfer-Encoding"
 #define HTTP_HEADER_USER_AGENT     "User-Agent"
 #define HTTP_HEADER_VALUE_CHUNKED  "chunked"
@@ -294,6 +295,10 @@ public:
     */
     void noDefaultRequestHeaders();
 
+    /** Enables using ServerAddress provided in ctor to be used for the Host header
+    */
+    void useServerAddressForHostHeader();
+
     // Inherited from Print
     // Note: 1st call to these indicates the user is sending the body, so if need
     // Note: be we should finish the header first
@@ -329,6 +334,10 @@ protected:
     */
     int sendInitialHeaders(const char* aURLPath,
                      const char* aHttpMethod);
+
+    /** Sends the host header.
+    */
+    void sendHostHeader();
 
     /* Let the server know that we've reached the end of the headers
     */
@@ -386,6 +395,7 @@ protected:
     uint32_t iHttpResponseTimeout;
     bool iConnectionClose;
     bool iSendDefaultRequestHeaders;
+    bool iUseServerAddressForHostHeader;
     String iHeaderLine;
 };
 


### PR DESCRIPTION
The HttpClient can be initialized with a ServerName(string) or ServerAddress (IPAddress). In the first case the underlaying Client will use DNS lookup to translate the name to the IP address. This lookup code is consuming extra bytes in memory. When making the HTTP request the ServerName is used for Host header.
If the ServerAddress is specified in the ctor of the HttpClient then the HTTP requests are missing the Host header. 

In this diff the user has ability to call useServerAddressForHostHeader to use the ServerAddress for the Host header.

As a workaround without this fix one has to use sendHeader / beginBody / endRequest call which makes the API use very cumbersome and error prone .
