### PR TITLE
ContentLength can go over 2 byte int

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -542,7 +542,7 @@ bool HttpClient::endOfHeadersReached()
     return (iState == eReadingBody || iState == eReadingChunkLength || iState == eReadingBodyChunk);
 };
 
-int HttpClient::contentLength()
+long HttpClient::contentLength()
 {
     // skip the response headers, if they haven't been read already 
     if (!endOfHeadersReached())

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -272,7 +272,7 @@ public:
       @return Length of the body, in bytes, or kNoContentLengthHeader if no
       Content-Length header was returned by the server
     */
-    int contentLength();
+    long contentLength();
 
     /** Returns if the response body is chunked
       @return true if response body is chunked, false otherwise
@@ -372,7 +372,7 @@ protected:
     // Stores the status code for the response, once known
     int iStatusCode;
     // Stores the value of the Content-Length header, if present
-    int iContentLength;
+    long iContentLength;
     // How many bytes of the response body have been read by the user
     int iBodyLengthConsumed;
     // How far through a Content-Length header prefix we are


### PR DESCRIPTION
When i tried to download a file over 64k i got issues on a arduinomega. This change will make the content length of type long so it will be 4 bytes. 