### PR TITLE
Support additional headers in WebSocketClient

### DIFF
--- a/src/WebSocketClient.h
+++ b/src/WebSocketClient.h
@@ -25,7 +25,7 @@ public:
     /** Start the Web Socket connection to the specified path with headers
       @param aPath     Path to use in request
       @param additionalHeaders  2D array with headers
-      @param headerRows  amound of rows in additionalHeaders array
+      @param headerRows  amount of rows in additionalHeaders array
       @return 0 if successful, else error
      */
     int begin(const char* aPath, char* (*additionalHeaders)[2], size_t headerRows);

--- a/src/WebSocketClient.h
+++ b/src/WebSocketClient.h
@@ -22,6 +22,13 @@ public:
     WebSocketClient(Client& aClient, const String& aServerName, uint16_t aServerPort = HttpClient::kHttpPort);
     WebSocketClient(Client& aClient, const IPAddress& aServerAddress, uint16_t aServerPort = HttpClient::kHttpPort);
 
+    /** Start the Web Socket connection to the specified path with headers
+      @param aPath     Path to use in request
+      @param additionalHeaders  2D array with headers
+      @param headerRows  amound of rows in additionalHeaders array
+      @return 0 if successful, else error
+     */
+    int begin(const char* aPath, char* (*additionalHeaders)[2], size_t headerRows);
     /** Start the Web Socket connection to the specified path
       @param aURLPath     Path to use in request (optional, "/" is used by default)
       @return 0 if successful, else error


### PR DESCRIPTION
Allows users of this library to add headers to the opening WebSocket request.

Example usage:

```cpp
char* socketHeaders[2][2];
socketHeaders[0][0] = "Cookie";
socketHeaders[0][1] = "mycookie=withValue";
socketHeaders[1][0] = "Origin";
socketHeaders[1][1] = "http://www.example.com";

client.begin("/socket", socketHeaders, 2);
```