### PR TITLE
Changed startRequest logic to fix compiler warning

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -84,7 +84,7 @@ int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
     {
         if (iServerName)
         {
-            if (!(iClient->connect(iServerName, iServerPort) > 0))
+            if (iClient->connect(iServerName, iServerPort) < 1)
             {
 #ifdef LOGGING
                 Serial.println("Connection failed");
@@ -94,7 +94,7 @@ int HttpClient::startRequest(const char* aURLPath, const char* aHttpMethod,
         }
         else
         {
-            if (!(iClient->connect(iServerAddress, iServerPort) > 0))
+            if (iClient->connect(iServerAddress, iServerPort) < 1)
             {
 #ifdef LOGGING
                 Serial.println("Connection failed");


### PR DESCRIPTION
Changed the startReqest client checking logic to iClient->connect(iServerName, iServerPort) < 1 to fix the error referenced in #97 :

ArduinoHttpClient-0.4.0/src/HttpClient.cpp:87:61: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
             if (!iClient->connect(iServerName, iServerPort) > 0)

This is a problem when using ESP32 with compiler warnings enabled as they set the -Werror option.