### PR TITLE
Renamed HttpClient files to Http_Client

### DIFF
--- a/src/ArduinoHttpClient.h
+++ b/src/ArduinoHttpClient.h
@@ -5,7 +5,7 @@
 #ifndef ArduinoHttpClient_h
 #define ArduinoHttpClient_h
 
-#include "HttpClient.h"
+#include "Http_Client.h"
 #include "WebSocketClient.h"
 #include "URLEncoder.h"
 

--- a/src/Http_Client.cpp
+++ b/src/Http_Client.cpp
@@ -2,7 +2,7 @@
 // (c) Copyright 2010-2011 MCQN Ltd
 // Released under Apache License, version 2.0
 
-#include "HttpClient.h"
+#include "Http_Client.h"
 #include "b64.h"
 
 // Initialize constants

--- a/src/Http_Client.h
+++ b/src/Http_Client.h
@@ -2,8 +2,8 @@
 // (c) Copyright MCQN Ltd. 2010-2012
 // Released under Apache License, version 2.0
 
-#ifndef HttpClient_h
-#define HttpClient_h
+#ifndef Http_Client_h
+#define Http_Client_h
 
 #include <Arduino.h>
 #include <IPAddress.h>

--- a/src/WebSocketClient.h
+++ b/src/WebSocketClient.h
@@ -6,7 +6,7 @@
 
 #include <Arduino.h>
 
-#include "HttpClient.h"
+#include "Http_Client.h"
 
 static const int TYPE_CONTINUATION     = 0x0;
 static const int TYPE_TEXT             = 0x1;


### PR DESCRIPTION
In order to make HttpClient also compatible with arduino-esp32 HTTPClient class, I have renamed the HttpClient files to Http_Client. This solves the issue https://github.com/arduino-libraries/ArduinoHttpClient/issues/91 too.