### PR TITLE
Reduce timeout from 1000ms to 100ms

### DIFF
--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -340,7 +340,7 @@ protected:
 
     // Number of milliseconds that we wait each time there isn't any data
     // available to be read (during status code and header processing)
-    static const int kHttpWaitForDataDelay = 1000;
+    static const int kHttpWaitForDataDelay = 100;
     // Number of milliseconds that we'll wait in total without receiving any
     // data before returning HTTP_ERROR_TIMED_OUT (during status code and header
     // processing)


### PR DESCRIPTION
Using this with the Arduino `WiFiClient` makes simple requests really slow. Reduce the timeout in order to make it faster.