### PR TITLE
Update state on connect

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -858,5 +858,18 @@ int HttpClient::readHeader()
     return c;
 }
 
+int HttpClient::connect(IPAddress ip, uint16_t port) {
+    this->iServerName = NULL;
+    this->iServerAddress = ip;
+    this-> iServerPort = port;
+    return iClient->connect(ip, port);
+};
+int HttpClient::connect(const char *host, uint16_t port) {
+    this->iServerName = host;
+    this->iServerAddress = IPAddress();
+    this-> iServerPort = port;
+    return iClient->connect(host, port);
+};
+
 
 

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -310,8 +310,8 @@ public:
     virtual void flush() { iClient->flush(); };
 
     // Inherited from Client
-    virtual int connect(IPAddress ip, uint16_t port) { return iClient->connect(ip, port); };
-    virtual int connect(const char *host, uint16_t port) { return iClient->connect(host, port); };
+    virtual int connect(IPAddress ip, uint16_t port);
+    virtual int connect(const char *host, uint16_t port);
     virtual void stop();
     virtual uint8_t connected() { return iClient->connected(); };
     virtual operator bool() { return bool(iClient); };


### PR DESCRIPTION
HttpClient implements inherited `Client::connect(IPAddress ip, uint16_t port)` and `Client::connect(const char *host, uint16_t port)`. The existing implementation is to simple: it does not update internal state variables `iServerName`, `iServerAddress`and `iServerPort`, but just invokes the wrapped client. This causes subsequent requests to be incorrect (e.g. wrong `host` header).

This PR changes `connect` to also update state.