### PR TITLE
Fix incorrect calculation in `WebSocketClient.cpp`

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -167,7 +167,7 @@ size_t WebSocketClient::write(const uint8_t *aBuffer, size_t aSize)
     // check if the write size, fits in the buffer
     if ((iTxSize + aSize) > sizeof(iTxBuffer))
     {
-        aSize = sizeof(iTxSize) - iTxSize;
+        aSize = sizeof(iTxBuffer) - iTxSize;
     }
 
     // copy data into the buffer


### PR DESCRIPTION
I think the remained buffer size is `sizeof(iTxBuffer) - iTxSize`, is that right?