### PR TITLE
Make sure to use HttpClient when upgrading the connection for websockets

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -421,7 +421,7 @@ int HttpClient::responseStatusCode()
         {
             if (available())
             {
-                c = read();
+                c = HttpClient::read();
                 if (c != -1)
                 {
                     switch(iState)
@@ -762,7 +762,7 @@ int HttpClient::read(uint8_t *buf, size_t size)
 
 int HttpClient::readHeader()
 {
-    char c = read();
+    char c = HttpClient::read();
 
     if (endOfHeadersReached())
     {


### PR DESCRIPTION
_disclaimer: I'm a bit puzzled by this problem, as everyone should have this problem but then people would have a lot of problems with websockets_

Context: I'm using websockets over https, using `WiFiClientSecure`

Using WebSocketClient::begin I got into problems where `status = responseStatusCode();` would be trying to read the HTTP header, but because both HttpClient and WebSocketClient have a read function, the read from WebSocketClient was used, which returns a bunch of gibberish bytes. This caused the WebSocket to think that the connection was not successfully upgraded, whereas in reality the webserver gave a proper response.

```
websocketClient = new WebSocketClient(wifiWebsocket, "www.host.com", 443);
int ret = websocketClient->begin(websocketPath);
```

this basically gave `ret = -4`, because `responseStatusCode` couldn't find the HTTP header.

Let me know what the structure is to get things merged, or what adaptations are required.

(I tested this on a simple esp32 board)

