### PR TITLE
Add ability to set response wait time

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -40,6 +40,7 @@ void HttpClient::resetState()
   iIsChunked = false;
   iChunkLength = 0;
   iHttpResponseTimeout = kHttpResponseTimeout;
+  iHttpWaitForDataDelay = kHttpWaitForDataDelay;
 }
 
 void HttpClient::stop()
@@ -473,7 +474,7 @@ int HttpClient::responseStatusCode()
             {
                 // We haven't got any data, so let's pause to allow some to
                 // arrive
-                delay(kHttpWaitForDataDelay);
+                delay(iHttpWaitForDataDelay);
             }
         }
         if ( (c == '\n') && (iStatusCode < 200 && iStatusCode != 101) )
@@ -522,7 +523,7 @@ int HttpClient::skipResponseHeaders()
         {
             // We haven't got any data, so let's pause to allow some to
             // arrive
-            delay(kHttpWaitForDataDelay);
+            delay(iHttpWaitForDataDelay);
         }
     }
     if (endOfHeadersReached())

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -317,6 +317,8 @@ public:
     virtual operator bool() { return bool(iClient); };
     virtual uint32_t httpResponseTimeout() { return iHttpResponseTimeout; };
     virtual void setHttpResponseTimeout(uint32_t timeout) { iHttpResponseTimeout = timeout; };
+    virtual uint32_t httpWaitForDataDelay() { return iHttpWaitForDataDelay; };
+    virtual void setHttpWaitForDataDelay(uint32_t delay) { iHttpWaitForDataDelay = delay; };
 protected:
     /** Reset internal state data back to the "just initialised" state
     */

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -384,6 +384,7 @@ protected:
     // Stores the value of the current chunk length, if present
     int iChunkLength;
     uint32_t iHttpResponseTimeout;
+    uint32_t iHttpWaitForDataDelay;
     bool iConnectionClose;
     bool iSendDefaultRequestHeaders;
     String iHeaderLine;


### PR DESCRIPTION
In my use cases a good amount of requests take way less than 1000 milliseconds to get a reply

I would like a way to use less delay than **kHttpWaitForDataDelay** to avoid unnecessarily hurting performance