### PR TITLE
Fix for ESP32 3.x NetworkClient, Client interface

### DIFF
--- a/src/ArduinoHttpClient.h
+++ b/src/ArduinoHttpClient.h
@@ -5,6 +5,12 @@
 #ifndef ArduinoHttpClient_h
 #define ArduinoHttpClient_h
 
+#if defined(ESP_IDF_VERSION)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#define HAS_ESP_IDF_5
+#endif
+#endif
+
 #include "HttpClient.h"
 #include "WebSocketClient.h"
 #include "URLEncoder.h"

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -313,7 +313,7 @@ public:
     // Inherited from Client
     virtual int connect(IPAddress ip, uint16_t port) { return iClient->connect(ip, port); };
     virtual int connect(const char *host, uint16_t port) { return iClient->connect(host, port); };
-    #ifdef ARDUINO_ARCH_ESP32
+    #ifdef HAS_ESP_IDF_5
     virtual int connect(const char *host, uint16_t port, int32_t timeout){ return iClient->connect(host, port, timeout); };
     virtual int connect(IPAddress ip, uint16_t port, int32_t timeout){ return iClient->connect(ip, port, timeout); };
     #endif

--- a/src/HttpClient.h
+++ b/src/HttpClient.h
@@ -313,6 +313,10 @@ public:
     // Inherited from Client
     virtual int connect(IPAddress ip, uint16_t port) { return iClient->connect(ip, port); };
     virtual int connect(const char *host, uint16_t port) { return iClient->connect(host, port); };
+    #ifdef ARDUINO_ARCH_ESP32
+    virtual int connect(const char *host, uint16_t port, int32_t timeout){ return iClient->connect(host, port, timeout); };
+    virtual int connect(IPAddress ip, uint16_t port, int32_t timeout){ return iClient->connect(ip, port, timeout); };
+    #endif
     virtual void stop();
     virtual uint8_t connected() { return iClient->connected(); };
     virtual operator bool() { return bool(iClient); };


### PR DESCRIPTION
@facchinm  @andreagilardoni Hi - this pull request allows this library to be used with the ESP32 board support package 3.x (Arduino ESP32 v3.0 based on ESP-IDF v5.1)by adding two extra `connect()` definitions into this library's `HTTPClient.h` to match the updated `Client`-type interfaces within ESP32, `NetworkClient` and `NetworkSecureClient`.

Since the bug only impacts devices running ESP32 on ESP-IDF 5.x or greater, I've provided a macro to detect the ESP-IDF version and a conditional inclusion guard around these two `virtual` `connect()` header-only interfaces.


The PR fixes the following compiler error (compiled with ESP Arduino 3.1.0 RC1):
```
src/wifi/AdafruitIO_ESP32.cpp:26:52: error: invalid new-expression of abstract class type 'HttpClient'
   26 |   _http = new HttpClient(_client, _host, _http_port);
      |                                                    ^
In file included from /Users/brentrubell/Documents/Arduino/libraries/ArduinoHttpClient/src/ArduinoHttpClient.h:8,
                 from /Users/brentrubell/Documents/Arduino/libraries/Adafruit_IO_Arduino/src/AdafruitIO.h:27,
                 from /Users/brentrubell/Documents/Arduino/libraries/Adafruit_IO_Arduino/src/wifi/AdafruitIO_ESP32.h:20:
/Users/brentrubell/Documents/Arduino/libraries/ArduinoHttpClient/src/HttpClient.h:41:7: note:   because the following virtual functions are pure within 'HttpClient':
   41 | class HttpClient : public Client
      |       ^~~~~~~~~~
In file included from /Users/brentrubell/Library/Arduino15/packages/esp32/hardware/esp32/3.1.0-RC1/cores/esp32/Arduino.h:197,
                 from /Users/brentrubell/Documents/Arduino/libraries/Adafruit_IO_Arduino/src/AdafruitIO_Dashboard.h:19,
                 from /Users/brentrubell/Documents/Arduino/libraries/Adafruit_IO_Arduino/src/AdafruitIO.h:19:
/Users/brentrubell/Library/Arduino15/packages/esp32/hardware/esp32/3.1.0-RC1/cores/esp32/Client.h:29:15: note:     'virtual int Client::connect(IPAddress, uint16_t, int32_t)'
   29 |   virtual int connect(IPAddress ip, uint16_t port, int32_t timeout) = 0;
      |               ^~~~~~~
/Users/brentrubell/Library/Arduino15/packages/esp32/hardware/esp32/3.1.0-RC1/cores/esp32/Client.h:31:15: note:     'virtual int Client::connect(const char*, uint16_t, int32_t)'
   31 |   virtual int connect(const char *host, uint16_t port, int32_t timeout) = 0;
      |               ^~~
```