### PR TITLE
Fix integer overflow

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -827,10 +827,10 @@ int HttpClient::readHeader()
     case eReadingContentLength:
         if (isdigit(c))
         {
-            long _iContentLength = iContentLength*10 + (c - '0');
-            // Only apply if the value didn't wrap around
-            if (_iContentLength > iContentLength) {
-                iContentLength = _iContentLength;
+            int digitValue = c - '0';
+            // Only apply if the value fits in long without overflow.
+            if (iContentLength <= ((LONG_MAX - digitValue) / 10)) {
+                iContentLength = iContentLength * 10 + digitValue;
             }
         }
         else

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -4,6 +4,7 @@
 
 #include "HttpClient.h"
 #include "b64.h"
+#include <limits.h>
 
 // Initialize constants
 const char* HttpClient::kUserAgent = "Arduino/2.2.0";
@@ -625,8 +626,12 @@ int HttpClient::available()
             else if (isHexadecimalDigit(c))
             {
                 char digit[2] = {c, '\0'};
+                int digitValue = (int)strtol(digit, NULL, 16);
 
-                iChunkLength = (iChunkLength * 16) + strtol(digit, NULL, 16);
+                // Only apply if the value fits in int without overflow.
+                if (iChunkLength <= ((INT_MAX - digitValue) / 16)) {
+                    iChunkLength = (iChunkLength * 16) + digitValue;
+                }
             }
         }
     }

--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -678,7 +678,10 @@ int HttpClient::read()
 
         if (iState == eReadingBodyChunk)
         {
-            iChunkLength--;
+            if (iChunkLength > 0)
+            {
+                iChunkLength--;
+            }
 
             if (iChunkLength == 0)
             {


### PR DESCRIPTION
Chunk size is accumulated from hex digits with no bounds check, so a long
enough size overflows iChunkLength (int) - UB, yielding a bogus/negative
length. Guard the accumulation with an INT_MAX pre-check so it can never
overflow.