### PR TITLE
Fix typo in WebSocketClient::write buffer size clamp

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -167,7 +167,7 @@ size_t WebSocketClient::write(const uint8_t *aBuffer, size_t aSize)
     // check if the write size, fits in the buffer
     if ((iTxSize + aSize) > sizeof(iTxBuffer))
     {
-        aSize = sizeof(iTxSize) - iTxSize;
+        aSize = sizeof(iTxBuffer) - iTxSize;
     }
 
     // copy data into the buffer


### PR DESCRIPTION
Use sizeof(iTxBuffer) instead of sizeof(iTxSize) when computing the remaining space, preventing truncated writes and potential memcpy overflow.

Originally reported here https://github.com/arduino-libraries/ArduinoHttpClient/pull/141